### PR TITLE
ISSUE-16 Blacklist rules

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -15,7 +15,7 @@ const blacklist = ({
     if (/^(S\/?N)$/i.test(neighborhood)){
         return true;
     }
-    return /(apto|bloco|apartamento|casa|ap|bl\s\d+)\b/gi.test(street);
+    return /(apto|bloco|apartamento\s\d+)\b/gi.test(street);
 };
 
 const sanitizeAddress = (completeAddress) => {


### PR DESCRIPTION
Remove casa, ap, bl from street blacklist rules
Because of:
R. Casa do Ator, 924 - Vila Olímpia, São Paulo - SP, 04546-003, Brazil
R. Igarapé Água Azul, 358 - Conj. Hab. Santa Etelvina II, São Paulo - SP, 08485-310, Brazil

[ISSUE-16](https://github.com/Minutrade/br-address-parser/issues/16#issue-1087679807)